### PR TITLE
feat: added ad auth to the stac-browser

### DIFF
--- a/.github/workflows/docker-build-prod.yml
+++ b/.github/workflows/docker-build-prod.yml
@@ -13,6 +13,7 @@ on:
 jobs:
   docker-build-push-prod:
     runs-on: ubuntu-latest
+    environment: PROD_ENVIRONMENT
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3

--- a/.github/workflows/docker-build-prod.yml
+++ b/.github/workflows/docker-build-prod.yml
@@ -38,3 +38,5 @@ jobs:
           cache-to: type=registry,ref=${{ secrets.EO_PROJ_PROD_DOCKER_REGISTRY_URL }}/stac-browser:cache,mode=max
           push: true
           tags: ${{ secrets.EO_PROJ_PROD_DOCKER_REGISTRY_URL }}/stac-browser:${{ env.SHORT_SHA }}
+          build-args: |
+            catalog_url = ${{ secrets.STAC_BROWSER_CATALOG_URL }}

--- a/.github/workflows/docker-build-stage.yml
+++ b/.github/workflows/docker-build-stage.yml
@@ -13,6 +13,7 @@ on:
 jobs:
   docker-build-push-dev:
     runs-on: ubuntu-latest
+    environment: STAGING_ENVIRONMENT
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3

--- a/.github/workflows/docker-build-stage.yml
+++ b/.github/workflows/docker-build-stage.yml
@@ -38,3 +38,5 @@ jobs:
           cache-to: type=registry,ref=${{ secrets.EO_PROJ_STAGING_DOCKER_REGISTRY_URL }}/stac-browser:cache,mode=max
           push: true
           tags: ${{ secrets.EO_PROJ_STAGING_DOCKER_REGISTRY_URL }}/stac-browser:${{ env.SHORT_SHA }}
+          build-args: |
+            catalog_url = ${{ secrets.STAC_BROWSER_CATALOG_URL }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ COPY package.json .
 COPY .npmignore .
 RUN npm install
 COPY . .
+ENV VUE_APP_ENABLE_AUTH=1
 RUN npm run build -- --catalogUrl=${catalog_url}
 RUN pwd
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,16 @@
 FROM node:16 as build-step
+ARG catalog_url
 WORKDIR /usr/src/app
 COPY package.json .
 # COPY package-lock.json .
 COPY .npmignore .
 RUN npm install
 COPY . .
-EXPOSE 8080
-CMD ["npm","start","--"]
+RUN npm run build -- --catalogUrl=${catalog_url}
+RUN pwd
+
+# Get the nginx image and just move the build folder to the nginx folder
+FROM nginx:1.21.1-alpine
+COPY --from=build-step /usr/src/app/dist /usr/share/nginx/html
+EXPOSE 80
+CMD ["nginx", "-g", "daemon off;"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,9 @@ COPY package.json .
 COPY .npmignore .
 RUN npm install
 COPY . .
-ENV VUE_APP_ENABLE_AUTH=1
+# currently the env variable is not used, but it will be used in the future
+ENV VUE_APP_ENABLE_AUTH=1 
+RUN echo "Building with catalog_url: ${catalog_url}"
 RUN npm run build -- --catalogUrl=${catalog_url}
 RUN pwd
 

--- a/config.js
+++ b/config.js
@@ -1,8 +1,5 @@
-let catalogUrl = process.env.VUE_APP_CATALOG_URL;
-let headerValueForApim = process.env.VUE_APP_HEADER_VALUE_FOR_APIM;
-
 module.exports = {
-    catalogUrl: catalogUrl, // Must have a slash at the end for folders/APIs
+    catalogUrl: null,
     catalogTitle: "STAC Browser",
     allowExternalAccess: true, // Must be true if catalogUrl is not given
     allowedDomains: [],
@@ -39,9 +36,8 @@ module.exports = {
     defaultThumbnailSize: null,
     maxPreviewsOnMap: 50,
     crossOriginMedia: null,
-    requestHeaders: {
-        'Ocp-Apim-Subscription-Key': headerValueForApim
-    },
+    requestHeaders: {},
     requestQueryParameters: {},
     preprocessSTAC: null,
+    authConfig: null
 };

--- a/src/auth/auth.js
+++ b/src/auth/auth.js
@@ -1,0 +1,50 @@
+// Modules
+import axios from "axios";
+
+const getAADToken = async () => {
+  try {
+    const instance = axios.create();
+
+    // Get the Azure AD data from /.auth/me but dont crash if 404
+    const response = await instance.get("/.auth/me", {
+      validateStatus: (status) => status === 200 || status === 404,
+    });
+
+    // Check if the response is valid
+    if (response.status === 200) {
+      const { expires_on } = response.data[0];
+      const tokenExpiryDateTime = new Date(expires_on);
+      const now = new Date();
+      let timeToExpiry = tokenExpiryDateTime - now;
+      if (timeToExpiry < 300000) {
+        await instance.get("/.auth/refresh");
+      }
+
+      const newTokenResponse = await instance.get("/.auth/me");
+      const { id_token } = newTokenResponse.data[0];
+      return id_token;
+    }
+
+    // Implies we are localhost
+    if (response.status === 404) {
+      return null;
+    }
+  } catch (e) {
+    console.log("Error fetching AAD token:", e);
+  }
+
+  window.location.href = "/.auth/login/aad";
+  return null;
+};
+
+const auth = async () => {
+  axios.interceptors.request.use(async (config) => {
+    const token = await getAADToken();
+    if (token) {
+      config.headers.Authorization = `Bearer ${token}`;
+    }
+    return config;
+  });
+};
+
+export { getAADToken, auth };

--- a/src/main.js
+++ b/src/main.js
@@ -3,11 +3,12 @@ import init from "./init";
 
 // Auth
 import { auth } from "./auth/auth";
-let enableAuth = process.env.VUE_APP_ENABLE_AUTH || false;
-if (enableAuth !== false) {
-  auth();
-}
+// let enableAuth = process.env.VUE_APP_ENABLE_AUTH || false;
+// if (enableAuth !== false) {
+//   auth();
+// }
 
+auth();
 Vue.config.productionTip = false;
 
 init();

--- a/src/main.js
+++ b/src/main.js
@@ -1,6 +1,10 @@
 import Vue from "vue";
 import init from "./init";
 
+// Auth
+import { auth } from "./auth/auth";
+auth();
+
 Vue.config.productionTip = false;
 
 init();

--- a/src/main.js
+++ b/src/main.js
@@ -3,7 +3,10 @@ import init from "./init";
 
 // Auth
 import { auth } from "./auth/auth";
-auth();
+let enableAuth = process.env.VUE_APP_ENABLE_AUTH || false;
+if (enableAuth !== false) {
+  auth();
+}
 
 Vue.config.productionTip = false;
 


### PR DESCRIPTION
Inspected a bit around the stac-browser and realised it is using Axios to send requests to the stac-fastapi.

Hence, inherited the ad-auth component from the stac-portal frontend and just reused it for the stac browser.