### PR TITLE
fix: auth is only enabled in production

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -7,6 +7,7 @@
     "STAC_BROWSER_VERSION": "readonly",
     "CONFIG_PATH": "readonly",
     "CONFIG_CLI": "readonly",
+    "VUE_APP_ENABLE_AUTH": "readonly",
     "require": "readonly"
   },
   "extends": [

--- a/src/main.js
+++ b/src/main.js
@@ -3,12 +3,12 @@ import init from "./init";
 
 // Auth
 import { auth } from "./auth/auth";
-// let enableAuth = process.env.VUE_APP_ENABLE_AUTH || false;
-// if (enableAuth !== false) {
-//   auth();
-// }
 
-auth();
+// will be false unless NODE_ENV === 'production'
+if (VUE_APP_ENABLE_AUTH) {
+  auth();
+}
+
 Vue.config.productionTip = false;
 
 init();

--- a/vue.config.js
+++ b/vue.config.js
@@ -40,6 +40,7 @@ const config = {
       args[0].STAC_BROWSER_VERSION = JSON.stringify(pkgFile.version);
       args[0].CONFIG_PATH = JSON.stringify(configFile);
       args[0].CONFIG_CLI = JSON.stringify(argv);
+      args[0].VUE_APP_ENABLE_AUTH = JSON.stringify(process.env.NODE_ENV === 'production');
       return args;
     });
     webpackConfig.plugin('html').tap(args => {


### PR DESCRIPTION
auth is only enabled when NODE_ENV === 'production'
@james-hinton would you mind making sure that I've kept to best practices as I haven't worked with Vue before 
Does this fix mean that we dont need to set the VUE_APP_ENABLE_AUTH env var in the Dockerfile?